### PR TITLE
add support for headers

### DIFF
--- a/README.org
+++ b/README.org
@@ -80,7 +80,8 @@ message.  For example,
 
 Update the request object as necessary, and press ~C-c C-c~ inside the block.
 
-*** Configure ~:GRPC-BLOCK-PREFIX:~
+*** Configure
+**** ~:GRPC-BLOCK-PREFIX:~
 
 If you don't want any text to be added in front of each of your
 org-babel blocks, this can be set to ~:GRPC-BLOCK-PREFIX: nil~.  The
@@ -95,6 +96,18 @@ be used here:
   name, request and return types.
 - ~${req-type}~ :: the name of the request type.
 - ~${resp-type}~ :: the name of the response type.
+
+**** ~:GRPC-HEADERS:~
+
+Headers are gRPC's way of handing sideband information like authorization
+or request tracing information.
+
+~:GRPC-HEADERS:~ is a list of key value pairs that can be added to the
+properties block. For example:
+
+#+begin_src org
+:GRPC-HEADERS: requestId:c1ec552b-ed11-453a-86c1-dc9a653a6764 userId:27a56560-f7aa-477f-a2f5-dcf3a450f1c8
+#+end_src
 
 ** Troubleshooting
 

--- a/ob-grpc.el
+++ b/ob-grpc.el
@@ -46,6 +46,14 @@
     result))
 
 
+(defun ob-grpc--concat-headers (grpc-headers)
+  "Take a list of GRPC-HEADERS and return string of grpcurl cli arguments."
+  (let (result)
+    (dolist (item grpc-headers result)
+      (setq result (concat " -H " item result)))
+    result))
+
+
 (defun ob-grpc--grpcurl-list (proto-file import-paths &optional service)
   "When no SERVICE is provided, return a list of grpc services defined \
 in PROTO-FILE and IMPORT-PATHS.  Else return methods under SERVICE."
@@ -151,12 +159,14 @@ in PROTO-FILE and IMPORT-PATHS.  Else return methods under SERVICE."
   "Execute a grpc call with BODY as request, using grpcurl, with method and endpoint taken from PARAMS."
   (let* ((proto-file (org-entry-get nil "PROTO-FILE" t))
 	 (import-paths (split-string (org-entry-get nil "PROTO-IMPORT-PATH" t) " "))
+         (grpc-headers (split-string (org-entry-get nil "GRPC-HEADERS" t) " "))
 	 (grpc-endpoint (org-entry-get nil "GRPC-ENDPOINT" t))
 	 (plain-text (org-entry-get nil "PLAIN-TEXT" t))
          (method (alist-get :method params)))
     (shell-command-to-string
-     (message "grpcurl %s -proto %s %s -d %s \"%s\" \"%s\""
+     (message "grpcurl %s %s -proto %s %s -d %s \"%s\" \"%s\""
 	      (ob-grpc--concat-imports import-paths)
+              (ob-grpc--concat-headers grpc-headers)
 	      proto-file
 	      (if (equal plain-text "no") "" "-plaintext")
 	      (prin1-to-string body)


### PR DESCRIPTION
I needed headers for this to work for my use case, after looking into the documentation in grpcurl, it looks liked headers were supported, so I extended `ob-grpc` to also support headers. I tried to follow the existing patterns and add some documentation. Let me know if you'd like me to re-format the README in a different way.